### PR TITLE
Correction of translation into Russian

### DIFF
--- a/radeon-profile/translations/strings.ru.ts
+++ b/radeon-profile/translations/strings.ru.ts
@@ -695,7 +695,7 @@
     <message>
         <location filename="../gpu.cpp" line="772"/>
         <source>Supported modes</source>
-        <translation>Поддерживаемые модели</translation>
+        <translation>Поддерживаемые режимы</translation>
     </message>
     <message>
         <location filename="../gpu.cpp" line="795"/>


### PR DESCRIPTION
The correct translation of the word "modes" - "режимы"